### PR TITLE
Fixed issue where the user selected profile is not saved to outbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed issue where the user selected profile was not stored in AF-Connect-Outbox.
+
 ## [0.1.0]
 
 ### Added

--- a/app/public/js/main.bundle.js
+++ b/app/public/js/main.bundle.js
@@ -84,7 +84,6 @@ module.exports = class Envelope {
 "use strict";
 
 var cv;
-var selectedProfile = -1;
 
 let configElement = document.getElementById("config");
 let config = {
@@ -148,10 +147,12 @@ window.onConsentRejection = function onConsentRejection() {
 };
 
 window.onConsent = function onConsent() {
-  // Record CV in AF Connect OutBox
-  cv.profile = cv.profiles[selectedProfile];
+  // Clear out all but the selected profile before saving to Outbox
+  const specificProfile = cv.profiles[selectedProfile];
   delete cv.profiles;
+  cv.profiles = [specificProfile];
 
+  // Record CV in AF Connect OutBox
   return new Promise((resolve, reject) => {
     resolve();
   })

--- a/app/public/js/main.js
+++ b/app/public/js/main.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var cv;
-var selectedProfile = -1;
 
 let configElement = document.getElementById("config");
 let config = {
@@ -65,10 +64,12 @@ window.onConsentRejection = function onConsentRejection() {
 };
 
 window.onConsent = function onConsent() {
-  // Record CV in AF Connect OutBox
-  cv.profile = cv.profiles[selectedProfile];
+  // Clear out all but the selected profile before saving to Outbox
+  const specificProfile = cv.profiles[selectedProfile];
   delete cv.profiles;
+  cv.profiles = [specificProfile];
 
+  // Record CV in AF Connect OutBox
   return new Promise((resolve, reject) => {
     resolve();
   })


### PR DESCRIPTION
Fixes the issue where AF-Connect fails to save the selected profile into af-connect-outbox.

**This is not a breaking change, fixes the intended behavior.**