### PR TITLE
add check-connectivity middleware to express server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added possibility to change logged in AF user by clearing sso cookie.
 - Using 'check-connectivity' module to serve health endpoint.
 
+### Changed
+
+- Updated "check-connectivity" package to version, commit: 8a073c1
+
 ### Fixed
 
 - Catch and recovery from a rejected sso cookie situation.

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -50,6 +50,7 @@ app.engine("html", ejs.__express);
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 
+app.use(health.middleware());
 app.use("/css", express.static(__dirname + "/../public/css"));
 app.use("/img", express.static(__dirname + "/../public/img"));
 app.use("/js", express.static(__dirname + "/../public/js"));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1280,10 +1280,11 @@
       }
     },
     "check-connectivity": {
-      "version": "git+https://git@github.com/MagnumOpuses/check-connectivity.git#5fb6f0112b33bbd1244aefdbf85cb893b87bf842",
-      "from": "git+https://git@github.com/MagnumOpuses/check-connectivity.git",
+      "version": "git+https://git@github.com/MagnumOpuses/check-connectivity.git#8a073c11d5a04f836294e068afa7bc7daa8235a8",
+      "from": "git+https://git@github.com/MagnumOpuses/check-connectivity.git#8a073c1",
       "requires": {
         "check-dependencies": "^1.1.0",
+        "cors": "^2.8.5",
         "express": "^4.17.1",
         "http": "0.0.0",
         "node-fetch": "^2.6.0",
@@ -1595,6 +1596,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "create-ecdh": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "ajv": "^6.10.2",
     "browserify": "^16.5.0",
-    "check-connectivity": "git+https://git@github.com/MagnumOpuses/check-connectivity.git",
+    "check-connectivity": "git+https://git@github.com/MagnumOpuses/check-connectivity.git#8a073c1",
     "dotenv": "^8.1.0",
     "ejs": "^2.7.1",
     "express": "^4.17.1",


### PR DESCRIPTION
**What does this implement/fix?**

Ensures that a more recent version of the check-connectivity package is installed and added as middleware to our express server.