### PR TITLE
Properly remove cookie by expiration

### DIFF
--- a/app/public/js/main.bundle.js
+++ b/app/public/js/main.bundle.js
@@ -26,9 +26,10 @@ let getCookie = name => {
 };
 
 let clearCookie = name => {
+  // Only keep the top-level domain from the hostname.
   const split = location.hostname.split(".");
   const tld = split.slice(split.length - 2).join(".");
-  document.cookie = name + "=; path=/; domain=." + tld;
+  document.cookie = name + "=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=." + tld;
 };
 
 function onResponse(data) {

--- a/app/public/js/main.js
+++ b/app/public/js/main.js
@@ -25,9 +25,10 @@ let getCookie = name => {
 };
 
 let clearCookie = name => {
+  // Only keep the top-level domain from the hostname.
   const split = location.hostname.split(".");
   const tld = split.slice(split.length - 2).join(".");
-  document.cookie = name + "=; path=/; domain=." + tld;
+  document.cookie = name + "=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=." + tld;
 };
 
 function onResponse(data) {


### PR DESCRIPTION
Just setting a cookie to an empty string doesn't remove it. By setting the expire date to zero, it will no longer be visible.

```js
// Set a cookie, clear it, and show that it's still visible
> document.cookie = "test=foobar";
"test=foobar"
> document.cookie = "test=";
"test="
> document.cookie
"test="

// Expire the cookie, and show that it's now gone
document.cookie = "test=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
> "test=; expires=Thu, 01 Jan 1970 00:00:00 GMT"
document.cookie
> ""
```

This is documented at https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie