### PR TITLE
Consent form updated to use jobTitle and companyName parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ _Read move about environment configuration here: [dotenv](https://github.com/mot
 
 1. Create an `.env` file at the root of the `af-connect` directory with the following content.
 
-   This `.env` file is ignored by the rules set in `.gitignore`, therefore in this file you may freely customizable the deployment to your own needs.
-
    ```
    ##Only Localhost config
    LOCAL_PORT=443

--- a/app/views/partials/consentForm.ejs
+++ b/app/views/partials/consentForm.ejs
@@ -67,7 +67,7 @@
                         <% for(var i=0; i<data.transferObject.data[0].profiles.length; i++) {%>
                             <div>
                                 <label>
-                                        <input name="profileChoice" type="radio" type="button" data-toggle="collapse" data-target="#profile_<%= i %>" onclick="selectedProfile = <%= i %>;" /> <%= data.transferObject.data[0].profiles[i].profileName %>    
+                                        <input name="profileChoice" type="radio" type="button" data-toggle="collapse" data-target="#profile_<%= i %>" onclick="selectedProfile = <%= i %>;" /> <%= data.transferObject.data[0].profiles[i].profileName %>
                                 </label>
                             </div>
                         <% } %>
@@ -106,7 +106,7 @@
                                         <% } %>
                                         <% if (employment.start) { %>
                                             <strong>Period</strong><br>
-                                            <%= employment.start %> - 
+                                            <%= employment.start %> -
 
                                             <% if (employment.current) { %>
                                                 Pågående
@@ -118,7 +118,7 @@
                                         <hr>
                                     <% }) %>
                                 <% } %>
-                                
+
                                 <% if (data.transferObject.data[0].profiles[i].qualifications && data.transferObject.data[0].profiles[i].qualifications && data.transferObject.data[0].profiles[i].qualifications.length > 0) { %>
                                     <strong>Kvalifikationer</strong><br>
                                     <ul>
@@ -141,22 +141,20 @@
                 <div style="margin-top: 24px; font-size: 16pt; margin-bottom: 16px; font-weight: 500; font-size: 22pt;">Dela och slutför</div>
                 <div style="background-color: #f5f5f5; padding: 16px; width: 60%; margin: auto;">
                     <div style="text-align: left;">
-                        <div><b>JobTechDev</b> får bara använda informationen för följande syfte:</div>
+                        <div><b><%= data.sink.companyName %></b> får bara använda informationen för följande syfte:</div>
                         <ul style="margin-top: 16px">
-                            <% data.sink.purposeOfUse.forEach((purpose) => { %>
-                                <li><%= purpose %></li>
-                            <% }) %>
+                            <li>Ansökan till roll '<%= data.sink.jobTitle %>' på '<%= data.sink.companyName %>'</li>
                         </ul>
                     </div>
                 </div>
-                
+
                 <div style="padding: 16px; width: 60%; margin: auto; text-align: left;">
                     <div><input id="secrecyAgreement" type="checkbox" onclick="secrecyAgreement();"> Jag förstår att denna process häver sekretessen för de uppgifter jag väljer att dela.</div>
-                    <div><input id="transferAgreement" type="checkbox" onclick="transferAgreement();"> Jag ger mitt medgivande att Arbetsförmedlingen får hantera och överföra dessa uppgifter till <b>JobTechDev</b>.</div>
-                    <div><input id="reviewAgreement" type="checkbox" onclick="reviewAgreement();"> Jag har granskat uppgifterna och bekräftar att inga oönskade uppgifter ingår i överföringen till <b>JobTechDev</b>.</div>
+                    <div><input id="transferAgreement" type="checkbox" onclick="transferAgreement();"> Jag ger mitt medgivande att Arbetsförmedlingen får hantera och överföra dessa uppgifter till <b><%= data.sink.companyName %></b>.</div>
+                    <div><input id="reviewAgreement" type="checkbox" onclick="reviewAgreement();"> Jag har granskat uppgifterna och bekräftar att inga oönskade uppgifter ingår i överföringen till <b><%= data.sink.companyName %></b>.</div>
                     <div><input id="termsAgreement" type="checkbox" onclick="openTermsAgreement();"> Jag har läst och förstår bilagan: <a href="#" onclick="openTermsAgreement(); return false">Sekretessinformation</a>.</div>
                 </div>
-                
+
                 <div style="margin-top: 16px">
                     <button id="shareButton" style="background-color: #b9b9ca; color: white; border: grey solid 1px; border-radius: 4px; padding-left: 12px; padding-right: 12px; padding-top: 6px; padding-bottom: 6px" onclick="onConsent();" disabled>
                         Jag samtycker och vill dela min profil

--- a/app/views/partials/consentForm.ejs
+++ b/app/views/partials/consentForm.ejs
@@ -141,28 +141,28 @@
                 <div style="margin-top: 24px; font-size: 16pt; margin-bottom: 16px; font-weight: 500; font-size: 22pt;">Dela och slutför</div>
                 <div style="background-color: #f5f5f5; padding: 16px; width: 60%; margin: auto;">
                     <div style="text-align: left;">
-                        <div><b><%= data.sink.companyName %></b> får bara använda informationen för följande syfte:</div>
-                        <ul style="margin-top: 16px">
-                            <li>Ansökan till roll '<%= data.sink.jobTitle %>' på '<%= data.sink.companyName %>'</li>
-                        </ul>
-                    </div>
-                </div>
+                      <div><b><%= data.sink.companyName %></b> får bara använda informationen för följande syfte:</div>
+                      <ul style="margin-top: 16px">
+                          <li>Ansökan till roll '<%= data.sink.jobTitle %>' på '<%= data.sink.companyName %>'</li>
+                      </ul>
+                  </div>
+              </div>
 
-                <div style="padding: 16px; width: 60%; margin: auto; text-align: left;">
-                    <div><input id="secrecyAgreement" type="checkbox" onclick="secrecyAgreement();"> Jag förstår att denna process häver sekretessen för de uppgifter jag väljer att dela.</div>
-                    <div><input id="transferAgreement" type="checkbox" onclick="transferAgreement();"> Jag ger mitt medgivande att Arbetsförmedlingen får hantera och överföra dessa uppgifter till <b><%= data.sink.companyName %></b>.</div>
-                    <div><input id="reviewAgreement" type="checkbox" onclick="reviewAgreement();"> Jag har granskat uppgifterna och bekräftar att inga oönskade uppgifter ingår i överföringen till <b><%= data.sink.companyName %></b>.</div>
-                    <div><input id="termsAgreement" type="checkbox" onclick="openTermsAgreement();"> Jag har läst och förstår bilagan: <a href="#" onclick="openTermsAgreement(); return false">Sekretessinformation</a>.</div>
-                </div>
+              <div style="padding: 16px; width: 60%; margin: auto; text-align: left;">
+                  <div><input id="secrecyAgreement" type="checkbox" onclick="secrecyAgreement();"> Jag förstår att denna process häver sekretessen för de uppgifter jag väljer att dela.</div>
+                  <div><input id="transferAgreement" type="checkbox" onclick="transferAgreement();"> Jag ger mitt medgivande att Arbetsförmedlingen får hantera och överföra dessa uppgifter till <b><%= data.sink.companyName %></b>.</div>
+                  <div><input id="reviewAgreement" type="checkbox" onclick="reviewAgreement();"> Jag har granskat uppgifterna och bekräftar att inga oönskade uppgifter ingår i överföringen till <b><%= data.sink.companyName %></b>.</div>
+                  <div><input id="termsAgreement" type="checkbox" onclick="openTermsAgreement();"> Jag har läst och förstår bilagan: <a href="#" onclick="openTermsAgreement(); return false">Sekretessinformation</a>.</div>
+              </div>
 
-                <div style="margin-top: 16px">
-                    <button id="shareButton" style="background-color: #b9b9ca; color: white; border: grey solid 1px; border-radius: 4px; padding-left: 12px; padding-right: 12px; padding-top: 6px; padding-bottom: 6px" onclick="onConsent();" disabled>
-                        Jag samtycker och vill dela min profil
-                    </button>
-                    <button style="background-color: white; color: black; border: #00005a solid 1px; border-radius: 4px; padding-left: 12px; padding-right: 12px; padding-top: 6px; padding-bottom: 6px" onclick="onConsentRejection();">
-                        Nej, dela inte min profil
-                    </button>
-                </div>
+              <div style="margin-top: 16px">
+                  <button id="shareButton" style="background-color: #b9b9ca; color: white; border: grey solid 1px; border-radius: 4px; padding-left: 12px; padding-right: 12px; padding-top: 6px; padding-bottom: 6px" onclick="onConsent();" disabled>
+                      Jag samtycker och vill dela min profil
+                  </button>
+                  <button style="background-color: white; color: black; border: #00005a solid 1px; border-radius: 4px; padding-left: 12px; padding-right: 12px; padding-top: 6px; padding-bottom: 6px" onclick="onConsentRejection();">
+                      Nej, dela inte min profil
+                  </button>
+              </div>
             </div>
         </div>
         <hr>
@@ -171,10 +171,10 @@
                 <div style="font-size: 16pt; margin-bottom: 16px">Sekretessinformation</div>
                 <div style="background-color: #f5f5f5; padding: 16px">
                     <ul style="margin-top: 16px">
-                        <li>Den här tjänsten gör det möjligt att skicka ditt valda CV till <b>JobTechDev</b>. Arbetsförmedlingen ansvarar inte för uppgifterna när de har levererats.</li>
+                        <li>Den här tjänsten gör det möjligt att skicka ditt valda CV till <b><%= data.sink.sinkName %></b>. Arbetsförmedlingen ansvarar inte för uppgifterna när de har levererats.</li>
                         <li>Ingen ytterligare data förknippat med dig lagras i samband med detta medgivande.</li>
                         <li>Klicka <a href="#">HÄR</a> för att lära dig mer om hur Arbetsförmedlingen behandlar dina uppgifter där de lagras, hur länge och vem som har åtkomst till dem.</li>
-                        <li><b>JobTechDev</b> är skyldigt att använda dina uppgifter enligt EU:s allmänna dataskyddsförordning. Klicka <a href="#">HÄR</a> om du vill veta mer om hur mottagningsföretaget behandlar dina uppgifter var lagras under hur länge, vem som har tillgång till dem etc.</li>
+                        <li><b><%= data.sink.sinkName %></b> är skyldigt att använda dina uppgifter enligt EU:s allmänna dataskyddsförordning. Klicka <a href="#">HÄR</a> om du vill veta mer om hur mottagningsföretaget behandlar dina uppgifter var lagras under hur länge, vem som har tillgång till dem etc.</li>
                         <li>Efter att uppgifterna har levererats kan Arbetsformedlingen inte verifiera
                             <ul>
                                 <li>hur eller var informationen kommer att lagras;</li>

--- a/app/views/partials/consentForm.ejs
+++ b/app/views/partials/consentForm.ejs
@@ -150,8 +150,10 @@
 
               <div style="padding: 16px; width: 60%; margin: auto; text-align: left;">
                   <div><input id="secrecyAgreement" type="checkbox" onclick="secrecyAgreement();"> Jag förstår att denna process häver sekretessen för de uppgifter jag väljer att dela.</div>
-                  <div><input id="transferAgreement" type="checkbox" onclick="transferAgreement();"> Jag ger mitt medgivande att Arbetsförmedlingen får hantera och överföra dessa uppgifter till <b><%= data.sink.companyName %></b>.</div>
-                  <div><input id="reviewAgreement" type="checkbox" onclick="reviewAgreement();"> Jag har granskat uppgifterna och bekräftar att inga oönskade uppgifter ingår i överföringen till <b><%= data.sink.companyName %></b>.</div>
+                  <div><input id="transferAgreement" type="checkbox" onclick="transferAgreement();"> Jag ger mitt medgivande att Arbetsförmedlingen får hantera och överföra dessa uppgifter till <b><%= data.sink.sinkName %></b>.</div>
+
+                  <div><input id="reviewAgreement" type="checkbox" onclick="reviewAgreement();"> Jag har granskat uppgifterna och bekräftar att inga oönskade uppgifter ingår i överföringen till <b><%= data.sink.sinkName %></b>.</div>
+
                   <div><input id="termsAgreement" type="checkbox" onclick="openTermsAgreement();"> Jag har läst och förstår bilagan: <a href="#" onclick="openTermsAgreement(); return false">Sekretessinformation</a>.</div>
               </div>
 


### PR DESCRIPTION
AF Connect API updated to include Job Title and Company Name
needed for the consent form in approving use
of AF user profile data.
These values arrive part of a data sink.
```
      <div><b>JobTechDev</b> får bara använda informationen för följande syfte:</div>
      <ul style="margin-top: 16px">
          <% data.sink.purposeOfUse.forEach((purpose) => { %>
              <li><%= purpose %></li>
          <% }) %>
      </ul>
```



af-connect handles rendering of the consent form.
