### PR TITLE
Added clickable URLs to consent form links

### DIFF
--- a/app/views/partials/consentForm.ejs
+++ b/app/views/partials/consentForm.ejs
@@ -191,8 +191,8 @@
         <img class="logo" src="/img/af-logo.svg" />
 
         <div style="margin: 8px 24px; font-size: 28pt">Förhandsvisning av din profil</div>
-        <div style="margin: 14px 0px 0px 24px; font-size: 17pt">Gå till Min Profil på Arbetsförmedlingen</div>
-        <div style="margin: 0 0 0 24px; font-size: 17pt">för att ändra dina uppgifter.</div>
+        <div style="margin: 14px 0px 0px 24px; font-size: 17pt">Gå till <a href="https://arbetsformedlingen.se/for-arbetssokande/mina-sidor/#/" target="_blank" onclick="window.open('','_parent',''); window.close(); return true;">Min Profil</a> på Arbetsförmedlingen</div>
+        <div style="margin: 0 0 0 24px; font-size: 17pt">för att ändra din information (detta avslutar applikationen).</div>
         <hr class="rule">
     </div>
 </header>
@@ -291,7 +291,7 @@
                         begäran.
                     </li>
                     <li style="margin-top: 18px">
-                        Klicka <a href="https://arbetsformedlingen.se/om-webbplatsen/juridisk-information/sa-hanterar-vi-dina-personuppgifter" target="_blank" rel="noopener noreferrer">HÄR</a> för att lära dig mer om hur Arbetsförmedlingen behandlar dina uppgifter.
+                        Klicka <a href="https://arbetsformedlingen.se/om-webbplatsen/juridisk-information/sa-hanterar-vi-dina-personuppgifter" target="_blank" rel="noopener noreferrer">här</a> för att lära dig mer om hur Arbetsförmedlingen behandlar dina uppgifter.
                     </li>
                     <li style="margin-top: 18px">
                         <%= data.sink.sinkName %> är skyldigt att använda dina uppgifter enligt EU:s allmänna dataskyddsförordning.


### PR DESCRIPTION
Also changed capital 'HÄR' to lower case 'här'.

Implemented closing popup on clicking on
profile URL and added text informing
this will happen if clicking the link.
Means aborting the consent / transfer process.

The onclick statement
onclick="window.open('','_parent',''); window.close(); return true;"
may not be bullet proof.

**Implements/Fixes**

...

**Comments/Notes**

...
