### PR TITLE
Added jumbotron Bootsatrap CSS  container to support mobile fullscreen

### DIFF
--- a/app/views/pages/index.ejs
+++ b/app/views/pages/index.ejs
@@ -13,7 +13,7 @@
     }
     .scr {
       font-size: 18pt;
-      color: lightgray;
+      color: white;
       text-align: left;
     }
     span {
@@ -36,7 +36,7 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     
     <!--    <link rel="stylesheet" href="/css/main.css" />  -->
 
@@ -47,20 +47,22 @@
   <body>
   <div id="config" data-af_login_url="<%= afLoginUrl %>"/>
 
-  <div id="consentForm" class="d-flex flex-column overflow-hidden min-vh-100 vh-100">
-  <!--  <header>
-        <img class="logo" src="/img/af-logo.svg" />
-    </header>  -->
+  <div class="jumbotron bg-white jumbotron-fluid">
+    <div id="consentForm" class="d-flex flex-column overflow-hidden min-vh-100 vh-100">
+    <!--  <header>
+          <img class="logo" src="/img/af-logo.svg" />
+      </header>  -->
 
-  <!--  <div id="consentForm"></div> -->
+    <!--  <div id="consentForm"></div> -->
 
-    <!-- Begin page content -->
+      <!-- Begin page content -->
 
-    <!-- Page headers -->
+      <!-- Page headers -->
 
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-Piv4xVNRyMGpqkS2by6br4gNJ7DXjqk09RmUpJ8jgGtD7zP9yug3goQfGII0yAns" crossorigin="anonymous"></script>
-    <script src="js/main.bundle.js"></script>
+      <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+      <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-Piv4xVNRyMGpqkS2by6br4gNJ7DXjqk09RmUpJ8jgGtD7zP9yug3goQfGII0yAns" crossorigin="anonymous"></script>
+      <script src="js/main.bundle.js"></script>
+    </div>
   </div>
   </body>
 </html>


### PR DESCRIPTION
Bootstrap CSS outer container added for mobile fullscreen mode.
iOS then enters full screen upon upwards page swipe operations.

**Implements/Fixes**
Adds Bootstrap CSS jumbotron outer container
which sets conditions enabling iOS full screen swipe.
...

This demo works in "floating navigation bar mode" for mobile (xs/sm/md)
which is a requested behavior for evaluation. Of interest to get more
vertical screen space for scrolled content.

lg/xl works wit a fixed footer

...
